### PR TITLE
Some changes & proposals

### DIFF
--- a/Chapter-10/chapter-10.md
+++ b/Chapter-10/chapter-10.md
@@ -323,7 +323,7 @@ Create a python script called `write-journal.py` and include this code after ins
 ```python
 from systemd import journal
 
-journal.write("Hello Lennart")
+journal.send("Hello Lennart")
 ```
 
 Give the above script execute permission, execute it by typing `python write-journal.py`, and the execute the command: `sudo journalctl -xe`, what do you see?


### PR DESCRIPTION
1/ Change the python script to journal.send instead of journal.write

2/ Last question of the LAB, for those SELinux like Fedora (I haven't tried on Ubuntu yet), you will not be able to run the service if the path is within your home folder. The script should be in location like /usr/bin/local with appropriate permission and you can start the service.